### PR TITLE
feat: Callout プラグインとスタイルを追加

### DIFF
--- a/themes/jpazure/scripts/callout.js
+++ b/themes/jpazure/scripts/callout.js
@@ -1,0 +1,41 @@
+/**
+ * Callout Plugin for Hexo
+ * Converts GitHub-style callout syntax to styled HTML
+ * Syntax: > [!TYPE]\n> content
+ */
+
+hexo.extend.filter.register('before_post_render', function(data) {
+  // Define callout types with their CSS class and icon
+  const calloutTypes = {
+    NOTE: ['note', 'ℹ️'],
+    TIP: ['tip', '💡'],
+    IMPORTANT: ['important', '❗'],
+    WARNING: ['warning', '⚠️'],
+    CAUTION: ['caution', '🔴']
+  };
+  
+  // Match pattern: > [!TYPE] followed by blockquote lines
+  const calloutPattern = /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n((?:>\s*.*\n?)*)/gmi;
+  
+  data.content = data.content.replace(calloutPattern, (match, type, blockquoteContent) => {
+    const typeUpper = type.toUpperCase();
+    const [cssClass, icon] = calloutTypes[typeUpper];
+    
+    // Remove '>' from blockquote lines and trim
+    const cleanContent = blockquoteContent.replace(/^>\s?/gm, '').trim();
+    
+    // Render markdown content to HTML
+    const renderedContent = hexo.render.renderSync({
+      text: cleanContent,
+      engine: 'markdown'
+    });
+    
+    // Return styled callout HTML
+    return `<div class="markdown-alert markdown-alert-${cssClass}">
+  <p class="markdown-alert-title">${icon} ${type}</p>
+  ${renderedContent}
+</div>`;
+  });
+  
+  return data;
+});

--- a/themes/jpazure/source/css/_partial/callout.styl
+++ b/themes/jpazure/source/css/_partial/callout.styl
@@ -1,0 +1,42 @@
+// Callout (Alert) Styles
+.markdown-alert
+  padding: 0.5rem 0.75rem
+  margin-bottom: 0.75rem
+  border-left: 3px solid
+  font-size: 0.95rem
+  
+  .markdown-alert-title
+    display: inline-flex
+    align-items: center
+    font-weight: 600
+    font-size: 0.9rem
+    margin-bottom: 0.25rem
+    margin-right: 0.5rem
+  
+  p
+    margin: 0.25rem 0
+
+.markdown-alert-note
+  background-color: #f0f9ff
+  border-color: #7dd3fc
+  color: #0c4a6e
+
+.markdown-alert-tip
+  background-color: #f0fdf9
+  border-color: #6ee7b7
+  color: #065f46
+
+.markdown-alert-important
+  background-color: #faf5ff
+  border-color: #c4b5fd
+  color: #6b21a8
+
+.markdown-alert-warning
+  background-color: #fffbeb
+  border-color: #fcd34d
+  color: #78350f
+
+.markdown-alert-caution
+  background-color: #fff1f2
+  border-color: #fca5a5
+  color: #991b1b

--- a/themes/jpazure/source/css/style.styl
+++ b/themes/jpazure/source/css/style.styl
@@ -91,6 +91,7 @@ if sidebar is left
 @import "_partial/highlight"
 @import "_partial/mobile"
 @import "_partial/issue-header"
+@import "_partial/callout"
 
 if sidebar
   @import "_partial/sidebar"


### PR DESCRIPTION
# 概要

callout プラグインを作成しました。

```
> [!NOTE]
> これはNOTEタイプの callout です。通常の情報を表示するのに使用します。
```

という形式で callout を記述できます。

以下は実際の表示例です。
<img width="1065" height="1021" alt="image" src="https://github.com/user-attachments/assets/411fe898-ac29-49c6-b0aa-9612fd57ced4" />
