### PR TITLE
feat: Archived タグを持つ記事にアーカイブ表示を追加

### DIFF
--- a/themes/jpazure/layout/_partial/article.ejs
+++ b/themes/jpazure/layout/_partial/article.ejs
@@ -22,9 +22,10 @@
     <div class="article-entry" itemprop="articleBody">
       <% var isArchived = post.tags && post.tags.some(function(tag){ return tag.name === 'Archived'; }); %>
       <% if (isArchived){ %>
+        <% var d = post.date; var archiveDate = d.format('YYYY/MM/DD'); %>
         <div class="markdown-alert markdown-alert-warning">
           <p class="markdown-alert-title">⚠️ WARNING</p>
-          <p>この記事はアーカイブされています。記載された技術情報は更新されていないため、現在の状況とは異なる可能性があります。</p>
+          <p>この記事は <%= archiveDate %> をもってアーカイブされました。当記事に記載された情報は最新でない可能性がありますのでご注意ください。</p>
         </div>
       <% } %>
       <% if (post.excerpt && index){ %>

--- a/themes/jpazure/layout/_partial/article.ejs
+++ b/themes/jpazure/layout/_partial/article.ejs
@@ -20,6 +20,13 @@
       </div>
     <% } %>
     <div class="article-entry" itemprop="articleBody">
+      <% var isArchived = post.tags && post.tags.some(function(tag){ return tag.name === 'Archived'; }); %>
+      <% if (isArchived){ %>
+        <div class="markdown-alert markdown-alert-warning">
+          <p class="markdown-alert-title">⚠️ WARNING</p>
+          <p>この記事はアーカイブされています。記載された技術情報は更新されていないため、現在の状況とは異なる可能性があります。</p>
+        </div>
+      <% } %>
       <% if (post.excerpt && index){ %>
         <%- post.excerpt %>
         <% if (theme.excerpt_link){ %>

--- a/themes/jpazure/layout/_partial/head.ejs
+++ b/themes/jpazure/layout/_partial/head.ejs
@@ -3,6 +3,10 @@
   <%- partial('google-analytics') %>
   <%
   var title = page.title;
+  var hasArchivedTag = page.tags && page.tags.some(function(tag){ return tag.name === 'Archived'; });
+  if (hasArchivedTag && title) {
+    title = '[Archived] ' + title;
+  }
 
   if (is_archive()){
     title = __('archive_a');

--- a/themes/jpazure/layout/_partial/post/title.ejs
+++ b/themes/jpazure/layout/_partial/post/title.ejs
@@ -1,15 +1,17 @@
+<% var isArchived = post.tags && post.tags.some(function(tag){ return tag.name === 'Archived'; }); %>
+<% var displayTitle = isArchived ? '[Archived] ' + post.title : post.title; %>
 <% if (post.link){ %>
   <h1 itemprop="name">
-    <a class="<%= class_name %>" href="<%- url_for(post.link) %>" target="_blank" itemprop="url"><%= post.title %></a>
+    <a class="<%= class_name %>" href="<%- url_for(post.link) %>" target="_blank" itemprop="url"><%= displayTitle %></a>
   </h1>
 <% } else if (post.title){ %>
   <% if (index){ %>
     <h1 itemprop="name">
-      <a class="<%= class_name %>" href="<%- url_for(post.path) %>"><%= post.title %></a>
+      <a class="<%= class_name %>" href="<%- url_for(post.path) %>"><%= displayTitle %></a>
     </h1>
   <% } else { %>
     <h1 class="<%= class_name %>" itemprop="name">
-      <%= post.title %>
+      <%= displayTitle %>
     </h1>
   <% } %>
 <% } %>

--- a/themes/jpazure/layout/_widget/recent_posts.ejs
+++ b/themes/jpazure/layout/_widget/recent_posts.ejs
@@ -4,8 +4,9 @@
     <div class="widget">
       <ul>
         <% site.posts.sort('date', -1).limit(5).each(function(post){ %>
+          <% var isArchived = post.tags && post.tags.some(function(tag){ return tag.name === 'Archived'; }); %>
           <li>
-            <a href="<%- url_for(post.path) %>"><%= post.title || '(no title)' %></a>
+            <a href="<%- url_for(post.path) %>"><%= isArchived ? '[Archived] ' + post.title : post.title || '(no title)' %></a>
           </li>
         <% }) %>
       </ul>


### PR DESCRIPTION
## 概要
Archived タグを持つ記事に対して、以下のアーカイブ表示を追加します。
(#3 を前提としています。)

### 変更内容
- 記事タイトルの先頭に `[Archived]` プレフィックスを表示 (`title.ejs`)
- ブラウザタブの `<title>` にも `[Archived]` プレフィックスを表示 (`head.ejs`)
- サイドバーの最近の投稿ウィジェットにも `[Archived]` プレフィックスを表示 (`recent_posts.ejs`)
- 記事本文の冒頭に WARNING callout バナーを表示 (`article.ejs`)
  - バナーに更新で frontmatter の date を表示するようにしました。

### 表示イメージ
<img width="769" height="320" alt="image" src="https://github.com/user-attachments/assets/fb69af61-6892-4531-bfd7-2f3712a8f470" />

※ この記事自体は現時点ではアーカイブされていません。


### 対象ファイル
- `themes/jpazure/layout/_partial/post/title.ejs`
- `themes/jpazure/layout/_partial/head.ejs`
- `themes/jpazure/layout/_widget/recent_posts.ejs`
- `themes/jpazure/layout/_partial/article.ejs`