### PR TITLE
fix: RSS フィードの updated を Git コミット日時から取得するように変更

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Initialize
         run: |

--- a/scripts/set-updated-from-git.js
+++ b/scripts/set-updated-from-git.js
@@ -1,0 +1,25 @@
+var execSync = require('child_process').execSync;
+var path = require('path');
+
+hexo.extend.filter.register('before_post_render', function(data) {
+  // Map post source path back to articles/ path
+  // post.source is like "_posts/teams/Title.md"
+  var relativePath = data.source.replace(/^_posts\//, '');
+  var articlesPath = path.join('articles', relativePath);
+
+  try {
+    var gitDate = execSync(
+      'git log -1 --format=%cI -- "' + articlesPath + '"',
+      { encoding: 'utf8', timeout: 5000 }
+    ).trim();
+
+    if (gitDate) {
+      data.updated = new Date(gitDate);
+    } else {
+      data.updated = data.date;
+    }
+  } catch (e) {
+    data.updated = data.date;
+  }
+  return data;
+});


### PR DESCRIPTION
## 概要

CI 環境で push するたびに、RSS フィード (atom.xml) の全記事の `<updated>` がビルド時刻に統一され、RSS リーダーに全件通知が飛ぶ問題を修正します。

## 原因

1. `actions/checkout` で全ファイルの mtime がチェックアウト時刻にリセットされる
2. gulp の `copyMarkdown` タスクで `articles/` → `source/_posts/` にコピーする際に mtime がコピー時刻になる
3. Hexo 4.2.0 が `post.updated` にファイルの mtime を使用する

結果として全記事の `<updated>` がビルド時刻に統一されます。

## 修正内容

### `scripts/set-updated-from-git.js`（新規追加）

Hexo の `before_post_render` フィルターで、各記事の `updated` を `articles/` パスに対する `git log -1` の最終コミット日時に上書きします。Git 履歴がない場合は front matter の `date` にフォールバックします。

### `.github/workflows/pages.yml`（変更）

`actions/checkout` に `fetch-depth: 0` を追加し、全 Git 履歴を取得します。これにより全記事の正しい最終コミット日時が保証されます。

## 効果

- 修正前: 全 20 エントリの `<updated>` がビルド時刻（例: `2026-04-13T08:46`）に統一
- 修正後: 各エントリが実際の最終コミット日時（`2024-03-01` ～ `2026-04-13` 等）を持つ

→ **変更した記事のみが RSS リーダーに通知される**ようになります。
